### PR TITLE
Compilation on RaspberryPI, GPIO, Raspbian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ musli:
 	gcc -Wall -DBACKEND_LIBUSB -o ldprog ldprog.c -lusb-1.0
 
 gpio:
-	gcc -Wall -DBACKEND_PIGPIO -o ldprog ldprog.c -lpigpio
+	gcc -Wall -DBACKEND_PIGPIO -o ldprog ldprog.c -lpigpio -pthread

--- a/ldprog.c
+++ b/ldprog.c
@@ -780,7 +780,9 @@ int main(int argc, char *argv[]) {
 	if ( ((options & OPTION_BONBON) == OPTION_BONBON) ||
 			((options & OPTION_KEKS) == OPTION_KEKS) ||
 			((options & OPTION_KOLIBRI) == OPTION_KOLIBRI) ) {
+#ifdef BACKEND_LIBUSB
 		musliInit(3);
+#endif
 	} else {
 		spi_release();
 	}
@@ -817,7 +819,9 @@ void fpga_reset(void) {
 };
 
 void spi_release(void) {
+#ifdef BACKEND_LIBUSB
 	musliInit(1);
+#endif
 	GPIO_SET_MODE(cspi_sck, PI_INPUT);
 	GPIO_SET_MODE(cspi_so, PI_INPUT);
 	GPIO_SET_MODE(cspi_si, PI_INPUT);


### PR DESCRIPTION
This PR contains two small fixes to allow for compilation of the GPIO version on Raspbian 9:
- Adding two defines in the C code to prevent `musliInit` being called when compiling for GPIO.
- Adding `-pthread` to the Makefile when compiling for GPIO on RaspberryPI.

These changes were required to compile on a RaspberryPI 3 B+, under Raspbian 9 (up to date as of yesterday).
Tested as working on a MMOD connected to GPIO.

Hope that helps! Thanks for great hardware and tools!